### PR TITLE
Ability to ignore redis-level errors in middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Note: this is helpful if your application sits behind a proxy (or set of proxies
 
 ChangeLog
 ---------
-* **1.2.1**
+* **1.3.0**
   * Add options to ExpressMiddleware constructor and support ignoring redis level errors
 * **1.2.0**
   * Remove `checkRequest` and `trackRequests` from middleware in favor of single `middleware` function

--- a/README.md
+++ b/README.md
@@ -84,7 +84,11 @@ var ExpressMiddleware = require('ratelimit.js').ExpressMiddleware;
 var redis = require('redis');
 
 var rateLimiter = new RateLimit(redis.createClient(), [{interval: 1, limit: 10}]);
-var limitMiddleware = new ExpressMiddleware(rateLimiter);
+
+var options = {
+  ignoreRedisErrors: true; // defaults to false
+};
+var limitMiddleware = new ExpressMiddleware(rateLimiter, options);
 ```
 
 Rate limit every endpoint of an express application:
@@ -137,6 +141,8 @@ Note: this is helpful if your application sits behind a proxy (or set of proxies
 
 ChangeLog
 ---------
+* **1.2.1**
+  * Add options to ExpressMiddleware constructor and support ignoring redis level errors
 * **1.2.0**
   * Remove `checkRequest` and `trackRequests` from middleware in favor of single `middleware` function
 * **1.1.0**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ratelimit.js",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "A NodeJS library for efficient rate limiting using sliding windows stored in Redis.",
   "keywords": [
     "rate limit",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ratelimit.js",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "A NodeJS library for efficient rate limiting using sliding windows stored in Redis.",
   "keywords": [
     "rate limit",

--- a/test/express_middleware_test.coffee
+++ b/test/express_middleware_test.coffee
@@ -61,3 +61,16 @@ describe 'Express Middleware', ->
         (done) =>
           @request().get('/').expect(429).end done
       ], done
+
+    it 'should ignore a redis-level error', (done) ->
+      @middleware.options.ignoreRedisErrors = true
+
+      @ratelimitMock
+        .expects('incr')
+        .withArgs(['127.0.0.1'])
+        .once()
+        .yields new Error()
+
+      @request().get('/').expect(200).end (err) =>
+        @ratelimitMock.verify()
+        done err


### PR DESCRIPTION
This is useful if your redis instance has some downtime or exceeds its
memory limits. Do not automatically fail if a redis-level error occurs.
