### PR TITLE
Add function to return rules violated by a key

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,8 @@ Note: this is helpful if your application sits behind a proxy (or set of proxies
 
 ChangeLog
 ---------
+* **1.4.0**
+  * Add `violatedRules` to RateLimit class to return the set of rules a key has violated
 * **1.3.0**
   * Add options to ExpressMiddleware constructor and support ignoring redis level errors
 * **1.2.0**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ratelimit.js",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "A NodeJS library for efficient rate limiting using sliding windows stored in Redis.",
   "keywords": [
     "rate limit",

--- a/test/integration_test.coffee
+++ b/test/integration_test.coffee
@@ -74,8 +74,7 @@ describe 'RateLimit', ->
         # Do one more request to put us over the top for the 2nd rule
         (callback) ->
           incrAndTrue null, done
-        ], (err) ->
-          done err
+        ], done
 
   describe 'check', ->
     it 'should not be limited if the key does not exist', (done) ->
@@ -91,4 +90,18 @@ describe 'RateLimit', ->
           ratelimit.check '127.0.0.1', (err, isLimited) ->
             isLimited.should.be.ok
             callback()
+      ], done
+
+  describe 'violatedRules', ->
+    it 'should return the set of rules a key has violated', (done) ->
+      async.series [
+        (callback) ->
+          bump 10, incrAndFalse, callback
+        (callback) ->
+          bump 1, incrAndTrue, callback
+        (callback) ->
+          ratelimit.violatedRules ['127.0.0.1'], (err, violated) ->
+            violated.length.should.eql 1
+            violated[0].should.eql {interval: 1, limit: 10}
+            callback err
       ], done


### PR DESCRIPTION
This allows you fetch the rules that a given key has violated. This is
useful if you want to let a user know what rule he or she is violating.

Fixes #3.
