### PR TITLE
Remove unnecessary variable defaulting

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,8 @@ Note: this is helpful if your application sits behind a proxy (or set of proxies
 
 ChangeLog
 ---------
+* **1.3.1**
+  * Small fix to `middleware` function in `ExpressMiddleware`
 * **1.3.0**
   * Add options to ExpressMiddleware constructor and support ignoring redis level errors
 * **1.2.0**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ratelimit.js",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "A NodeJS library for efficient rate limiting using sliding windows stored in Redis.",
   "keywords": [
     "rate limit",

--- a/src/express_middleware.coffee
+++ b/src/express_middleware.coffee
@@ -8,7 +8,7 @@ module.exports = class ExpressMiddleware
     [callback, extractIps] = [extractIps, null] unless callback
     extractIps or= @extractIpsFromReq
     (req, res, next) =>
-      @rateLimiter.incr extractIps(req), (err, isLimited = false) =>
+      @rateLimiter.incr extractIps(req), (err, isLimited) =>
         if err
           if @options.ignoreRedisErrors
             isLimited = false


### PR DESCRIPTION
This is a subtle fix but defaulting `isLimited` to false should only
happen if `options.ignoreRedisErrors` is set.
