### PR TITLE
Passing black/whitelist keys to Redis scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,24 @@ Is rate limited? true
 Is rate limited? true
 ```
 
+Constructor Usage:
+
+```javascript
+var RateLimit = require('ratelimit.js').RateLimit;
+var redis = require('redis');
+
+var client = redis.createClient();
+
+var rules = [
+  {interval: 3600, limit: 1000}
+  ];
+// You can define a prefix to be included on each redis entry
+// This prevents collisions if you have multiple applications
+// using the same redis db
+var limiter = new RateLimit(client, rules, 'RedisPrefix');
+```
+**NOTE:** If your redis library supports key prefixing like [ioredis](https://github.com/luin/ioredis#transparent-key-prefixing) does, this library will _not_ correctly resolve the whitelist/blacklist items.
+
 Whitelist/Blacklist Usage
 -------------------------
 

--- a/README.md
+++ b/README.md
@@ -198,6 +198,8 @@ Note: this is helpful if your application sits behind a proxy (or set of proxies
 
 ChangeLog
 ---------
+* **1.7.0**
+  * Fixed issue with whitelist and blacklist entries not being prefixed. Properly document prefix feature.
 * **1.6.1**
   * Remove unused redis require
 * **1.6.0**

--- a/README.md
+++ b/README.md
@@ -85,12 +85,16 @@ var client = redis.createClient();
 var rules = [
   {interval: 3600, limit: 1000}
   ];
+
 // You can define a prefix to be included on each redis entry
 // This prevents collisions if you have multiple applications
 // using the same redis db
 var limiter = new RateLimit(client, rules, 'RedisPrefix');
 ```
-**NOTE:** If your redis library supports key prefixing like [ioredis](https://github.com/luin/ioredis#transparent-key-prefixing) does, this library will _not_ correctly resolve the whitelist/blacklist items.
+**NOTE:** If your redis library supports key prefixing like
+[ioredis](https://github.com/luin/ioredis#transparent-key-prefixing)
+does, this library will _not_ correctly resolve the
+whitelist/blacklist items.
 
 Whitelist/Blacklist Usage
 -------------------------

--- a/README.md
+++ b/README.md
@@ -89,12 +89,22 @@ var rules = [
 // You can define a prefix to be included on each redis entry
 // This prevents collisions if you have multiple applications
 // using the same redis db
-var limiter = new RateLimit(client, rules, 'RedisPrefix');
+var limiter = new RateLimit(client, rules, {prefix: 'RedisPrefix'});
 ```
-**NOTE:** If your redis library supports key prefixing like
-[ioredis](https://github.com/luin/ioredis#transparent-key-prefixing)
-does, this library will _not_ correctly resolve the
-whitelist/blacklist items.
+
+**NOTE:** If your redis client supports transparent prefixing (like
+[ioredis](https://github.com/luin/ioredis#transparent-key-prefixing))
+the following configuration should be used:
+
+```javascript
+var limiter = new RateLimit(ioRedisClient, rules, {
+  prefix: ioRedisClient.keyPrefix,
+  clientPrefix: true
+});
+```
+
+This will only include the prefix in the whitelist/blacklist keys passed to
+the Lua scripts to be executed.
 
 Whitelist/Blacklist Usage
 -------------------------

--- a/lua/check_blacklist.lua
+++ b/lua/check_blacklist.lua
@@ -2,7 +2,7 @@
 if not is_whitelisted then
     -- Check the blacklist set for the given key
     for _, key in ipairs(KEYS) do
-        local is_set_member = redis.call('SISMEMBER', 'blacklist', key)
+        local is_set_member = redis.call('SISMEMBER', blacklist_key, key)
         is_set_member = tonumber(is_set_member)
         if is_set_member > 0 then
             is_blacklisted = true

--- a/lua/check_whitelist.lua
+++ b/lua/check_whitelist.lua
@@ -1,6 +1,6 @@
 -- Check the whitelist set for the given key
 for _, key in ipairs(KEYS) do
-    local is_set_member = redis.call('SISMEMBER', 'whitelist', key)
+    local is_set_member = redis.call('SISMEMBER', whitelist_key, key)
     is_set_member = tonumber(is_set_member)
     if is_set_member > 0 then
         is_whitelisted = true

--- a/lua/unpack_args.lua
+++ b/lua/unpack_args.lua
@@ -5,6 +5,8 @@ local weight = tonumber(ARGV[3] or '1')
 local longest_duration = limits[1][1] or 0
 local saved_keys = {}
 
--- Data for whitelist and blacklist
+-- Locals for whitelist and blacklist ops
+local whitelist_key = ARGV[4] or 'whitelist'
+local blacklist_key = ARGV[5] or 'blacklist'
 local is_whitelisted = false
 local is_blacklisted = false

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ratelimit.js",
-  "version": "1.6.1",
+  "version": "1.7.0",
   "description": "A NodeJS library for efficient rate limiting using sliding windows stored in Redis.",
   "keywords": [
     "rate limit",


### PR DESCRIPTION
This ensures that whitelists/blacklists are prefixed properly to protect from collisions. The members of the whitelist/blacklist sets need to have a prefix prepended as well due to the way the rate limit keys are tracked and passed around. Using the `RateLimit#blacklist` and `RateLimit#whitelist` functions will handle this for you.

Fixes https://github.com/dudleycarr/ratelimit.js/issues/15
