### PR TITLE
Adds support for precision property

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ var client = redis.createClient();
 
 var rules = [
   {interval: 1, limit: 5},
-  {interval: 3600, limit: 1000}
+  {interval: 3600, limit: 1000, precision: 10000}
   ];
 var limiter = new RateLimit(client, rules);
 
@@ -180,6 +180,8 @@ Note: this is helpful if your application sits behind a proxy (or set of proxies
 
 ChangeLog
 ---------
+* **1.6.2**
+  * Add support for precision property in rules objects
 * **1.6.1**
   * Remove unused redis require
 * **1.6.0**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ratelimit.js",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "description": "A NodeJS library for efficient rate limiting using sliding windows stored in Redis.",
   "keywords": [
     "rate limit",

--- a/src/rate_limit.coffee
+++ b/src/rate_limit.coffee
@@ -48,8 +48,8 @@ module.exports = class RateLimit
     ].join '\n'
 
   convertRules: (rules) ->
-    for rule in rules
-      [rule.interval, rule.limit]
+    for {interval, limit, precision} in rules
+      _.compact [interval, limit, precision]
 
   scriptArgs: (keys, weight = 1) ->
     # Keys has to be a list

--- a/src/rate_limit.coffee
+++ b/src/rate_limit.coffee
@@ -48,8 +48,8 @@ module.exports = class RateLimit
     ].join '\n'
 
   convertRules: (rules) ->
-    for {interval, limit, precision} in rules
-      [interval, limit, precision]
+    for {interval, limit, precision} in rules when interval and limit
+      _.compact [interval, limit, precision]
 
   scriptArgs: (keys, weight = 1) ->
     # Keys has to be a list

--- a/src/rate_limit.coffee
+++ b/src/rate_limit.coffee
@@ -49,7 +49,7 @@ module.exports = class RateLimit
 
   convertRules: (rules) ->
     for {interval, limit, precision} in rules
-      _.compact [interval, limit, precision]
+      [interval, limit, precision]
 
   scriptArgs: (keys, weight = 1) ->
     # Keys has to be a list


### PR DESCRIPTION
Now you are able to specify the precision for a given rate limit rule. Previously we were defaulting to the `interval` or `duration`. Simple fix really!

Fixes #14 
