### PR TITLE
Fix simplify whitelist blacklist lua code

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,8 @@ Note: this is helpful if your application sits behind a proxy (or set of proxies
 
 ChangeLog
 ---------
+* **1.7.1**
+  * Refactor whitelist/blacklist lua code to be simpler and slightly more performant
 * **1.7.0**
   * Fixed issue with whitelist and blacklist entries not being prefixed. Properly document prefix feature.
 * **1.6.2**

--- a/lua/check_blacklist.lua
+++ b/lua/check_blacklist.lua
@@ -1,8 +1,0 @@
--- Check the blacklist set for the given key
-for _, key in ipairs(KEYS) do
-    local is_set_member = redis.call('SISMEMBER', blacklist_key, key)
-    is_set_member = tonumber(is_set_member)
-    if is_set_member > 0 then
-        return 2
-    end
-end

--- a/lua/check_blacklist.lua
+++ b/lua/check_blacklist.lua
@@ -1,12 +1,8 @@
--- Skip if we're already whitelisted
-if not is_whitelisted then
-    -- Check the blacklist set for the given key
-    for _, key in ipairs(KEYS) do
-        local is_set_member = redis.call('SISMEMBER', blacklist_key, key)
-        is_set_member = tonumber(is_set_member)
-        if is_set_member > 0 then
-            is_blacklisted = true
-            break
-        end
+-- Check the blacklist set for the given key
+for _, key in ipairs(KEYS) do
+    local is_set_member = redis.call('SISMEMBER', blacklist_key, key)
+    is_set_member = tonumber(is_set_member)
+    if is_set_member > 0 then
+        return 2
     end
 end

--- a/lua/check_incr_limit.lua
+++ b/lua/check_incr_limit.lua
@@ -1,25 +1,22 @@
 -- Credit: http://www.dr-josiah.com/2014/11/introduction-to-rate-limiting-with_26.html
 
--- Return if the key(s) are whitelisted or blacklisted
-if not is_whitelisted and not is_blacklisted then
-    -- there is enough resources, update the counts
-    for i, limit in ipairs(limits) do
-        local saved = saved_keys[i]
+-- there is enough resources, update the counts
+for i, limit in ipairs(limits) do
+    local saved = saved_keys[i]
 
-        for j, key in ipairs(KEYS) do
-            -- update the current timestamp, count, and bucket count
-            redis.call('HSET', key, saved.ts_key, saved.trim_before)
-            redis.call('HINCRBY', key, saved.count_key, weight)
-            redis.call('HINCRBY', key, saved.count_key .. saved.block_id, weight)
-        end
+    for j, key in ipairs(KEYS) do
+        -- update the current timestamp, count, and bucket count
+        redis.call('HSET', key, saved.ts_key, saved.trim_before)
+        redis.call('HINCRBY', key, saved.count_key, weight)
+        redis.call('HINCRBY', key, saved.count_key .. saved.block_id, weight)
     end
+end
 
-    -- We calculated the longest-duration limit so we can EXPIRE
-    -- the whole HASH for quick and easy idle-time cleanup :)
-    if longest_duration > 0 then
-        for _, key in ipairs(KEYS) do
-            redis.call('EXPIRE', key, longest_duration)
-        end
+-- We calculated the longest-duration limit so we can EXPIRE
+-- the whole HASH for quick and easy idle-time cleanup :)
+if longest_duration > 0 then
+    for _, key in ipairs(KEYS) do
+        redis.call('EXPIRE', key, longest_duration)
     end
 end
 

--- a/lua/check_limit.lua
+++ b/lua/check_limit.lua
@@ -1,15 +1,5 @@
 -- Credit: http://www.dr-josiah.com/2014/11/introduction-to-rate-limiting-with_26.html
 
--- Return specific code for whitelisted keys
-if is_whitelisted then
-  return 0
-end
-
--- Return specific code for blacklisted keys
-if is_blacklisted then
-  return 2
-end
-
 -- handle cleanup and limit checks
 for i, limit in ipairs(limits) do
     local duration = limit[1]

--- a/lua/check_whitelist.lua
+++ b/lua/check_whitelist.lua
@@ -3,7 +3,6 @@ for _, key in ipairs(KEYS) do
     local is_set_member = redis.call('SISMEMBER', whitelist_key, key)
     is_set_member = tonumber(is_set_member)
     if is_set_member > 0 then
-        is_whitelisted = true
-        break
+        return 0
     end
 end

--- a/lua/check_whitelist.lua
+++ b/lua/check_whitelist.lua
@@ -1,8 +1,0 @@
--- Check the whitelist set for the given key
-for _, key in ipairs(KEYS) do
-    local is_set_member = redis.call('SISMEMBER', whitelist_key, key)
-    is_set_member = tonumber(is_set_member)
-    if is_set_member > 0 then
-        return 0
-    end
-end

--- a/lua/check_whitelist_blacklist.lua
+++ b/lua/check_whitelist_blacklist.lua
@@ -5,7 +5,7 @@ for _, key in ipairs(KEYS) do
         return 0
     end
 
-    local is_set_member = redis.call('SISMEMBER', blacklist_key, key)
+    is_set_member = redis.call('SISMEMBER', blacklist_key, key)
     if tonumber(is_set_member) > 0 then
         return 2
     end

--- a/lua/check_whitelist_blacklist.lua
+++ b/lua/check_whitelist_blacklist.lua
@@ -1,0 +1,12 @@
+-- Check the whitelist and blacklist sets for the given key
+for _, key in ipairs(KEYS) do
+    local is_set_member = redis.call('SISMEMBER', whitelist_key, key)
+    if tonumber(is_set_member) > 0 then
+        return 0
+    end
+
+    local is_set_member = redis.call('SISMEMBER', blacklist_key, key)
+    if tonumber(is_set_member) > 0 then
+        return 2
+    end
+end

--- a/lua/unpack_args.lua
+++ b/lua/unpack_args.lua
@@ -8,5 +8,3 @@ local saved_keys = {}
 -- Locals for whitelist and blacklist ops
 local whitelist_key = ARGV[4] or 'whitelist'
 local blacklist_key = ARGV[5] or 'blacklist'
-local is_whitelisted = false
-local is_blacklisted = false

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ratelimit.js",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "A NodeJS library for efficient rate limiting using sliding windows stored in Redis.",
   "keywords": [
     "rate limit",

--- a/src/rate_limit.coffee
+++ b/src/rate_limit.coffee
@@ -41,8 +41,7 @@ module.exports = class RateLimit
   checkLimitScript: ->
     [
       @readLua 'unpack_args'
-      @readLua 'check_whitelist'
-      @readLua 'check_blacklist'
+      @readLua 'check_whitelist_blacklist'
       @readLua 'check_limit'
       'return 0'
     ].join '\n'
@@ -50,8 +49,7 @@ module.exports = class RateLimit
   checkLimitIncrScript: ->
     [
       @readLua 'unpack_args'
-      @readLua 'check_whitelist'
-      @readLua 'check_blacklist'
+      @readLua 'check_whitelist_blacklist'
       @readLua 'check_limit'
       @readLua 'check_incr_limit'
     ].join '\n'


### PR DESCRIPTION
Well, TIL (yesterday technically) that you can just include early
returns in Redis Lua code. All the code is more or less concatenated, so
early returns will immediately halt execution of the remaining bits of
code. The if checks previously used are unnecessary. This also combines
the check whitelist and check blacklist scripts into a single script as there
is no real need to separate them.
